### PR TITLE
feat: add status object in getHistoryWithStatus response with latest entry

### DIFF
--- a/src/controllers/notarization.controller.js
+++ b/src/controllers/notarization.controller.js
@@ -52,7 +52,7 @@ const getHistoryByUserId = catchAsync(async (req, res) => {
 });
 
 const getHistoryWithStatus = catchAsync(async (req, res) => {
-  const { userId } = req.query;
+  const userId = req.user.id;
   const history = await notarizationService.getHistoryWithStatus(userId);
   res.status(httpStatus.OK).send(history);
 });

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -84,14 +84,14 @@ components:
           type: string
           format: date-time
         status:
-          type: string
+          type: object
           enum:
             - pending
             - processing
+            - verification
             - digitalSignature
-            - approved
+            - completed
             - rejected
-            - cancelled
     Session:
       type: object
       properties:

--- a/src/routes/v1/notarization.route.js
+++ b/src/routes/v1/notarization.route.js
@@ -731,4 +731,31 @@ router
  *         $ref: '#/components/responses/InternalServerError'
  */
 
+/**
+ * @swagger
+ * /notarization/get-history-with-status:
+ *   get:
+ *     summary: Get notarization history with status
+ *     tags: [Notarizations]
+ *     security:
+ *       - bearerAuth: []
+ *     responses:
+ *       "200":
+ *         description: Notarization history with status retrieved successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: array
+ *               items:
+ *                 $ref: '#/components/schemas/Notarizations'
+ *       "400":
+ *         $ref: '#/components/responses/BadRequest'
+ *       "401":
+ *         $ref: '#/components/responses/Unauthorized'
+ *       "403":
+ *         $ref: '#/components/responses/Forbidden'
+ *       "500":
+ *         $ref: '#/components/responses/InternalServerError'
+ */
+
 module.exports = router;


### PR DESCRIPTION
This pull request includes several updates to the notarization service, focusing on improving the retrieval of notarization history with status and enhancing the API documentation. The most important changes include modifying the `getHistoryWithStatus` function, updating the status schema, and adding Swagger documentation for the new endpoint.

### Improvements to notarization history retrieval:

* [`src/services/notarization.service.js`](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L134-R153): Refactored the `getHistoryWithStatus` function to use MongoDB's aggregation framework for more efficient data retrieval and status tracking.

### API documentation enhancements:

* [`src/routes/v1/notarization.route.js`](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659R734-R760): Added Swagger documentation for the new `get-history-with-status` endpoint, detailing the responses and security requirements.

### Schema updates:

* [`src/docs/components.yml`](diffhunk://#diff-848be3bdb1e3a2866f0025a7a1348c31f1d74cd2c521c7f99d5b71a9eac90f7aL87-L94): Updated the `status` property in the schema to be an object and added new status values.

### Controller updates:

* [`src/controllers/notarization.controller.js`](diffhunk://#diff-e0b1f720ebbfb63e320fdd6167ac55233175719d3e8487f857df8c9ca5d4e1c6L55-R55): Modified the `getHistoryWithStatus` controller to use `req.user.id` instead of `req.query.userId` for fetching user-specific history.

### Dependency additions:

* [`src/services/notarization.service.js`](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1R2): Added `ObjectId` from Mongoose to facilitate object ID creation in the service layer.