### PR TITLE
feat: extend allowed periods for payment metrics and enhance response with growth percentage

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -118,7 +118,7 @@ const getPaymentTotalByNotarizationField = catchAsync(async (req, res) => {
 
 const getPaymentTotal = catchAsync(async (req, res) => {
   const { period } = req.params;
-  const allowedPeriods = ['today', 'current_week', 'current_month', 'current_year'];
+  const allowedPeriods = ['today', 'yesterday', 'current_week', 'current_month', 'current_year'];
 
   if (!allowedPeriods.includes(period)) {
     return res.status(httpStatus.BAD_REQUEST).send({ message: 'Invalid period parameter' });

--- a/src/routes/v1/admin.route.js
+++ b/src/routes/v1/admin.route.js
@@ -406,8 +406,8 @@ module.exports = router;
  * @swagger
  * /admin/metrics/payments/{period}:
  *   get:
- *     summary: Get total payment value for a specified period
- *     description: Retrieve the total value of payments created for the specified period. Only admins can access this information.
+ *     summary: Get total payment value and growth percent for a specified period
+ *     description: Retrieve the total value of payments and growth percentage based on the specified period. Only admins can access this information.
  *     tags: [Admins]
  *     security:
  *       - bearerAuth: []
@@ -418,7 +418,7 @@ module.exports = router;
  *           type: string
  *           enum: [today, current_week, current_month, current_year]
  *         required: true
- *         description: The period to filter payments by
+ *         description: The period to retrieve payment metrics for
  *     responses:
  *       "200":
  *         description: Successful operation
@@ -427,12 +427,27 @@ module.exports = router;
  *             schema:
  *               type: object
  *               properties:
- *                 period:
- *                   type: string
- *                   example: "daily"
- *                 totalAmount:
+ *                 currentPeriod:
+ *                   type: object
+ *                   properties:
+ *                     period:
+ *                       type: string
+ *                       example: "today"
+ *                     totalAmount:
+ *                       type: number
+ *                       example: 1000
+ *                 previousPeriod:
+ *                   type: object
+ *                   properties:
+ *                     period:
+ *                       type: string
+ *                       example: "previous_today"
+ *                     totalAmount:
+ *                       type: number
+ *                       example: 800
+ *                 growthPercent:
  *                   type: number
- *                   example: 1000
+ *                   example: 25
  *       "400":
  *         description: Bad Request - Invalid period parameter
  *         content:


### PR DESCRIPTION
This pull request enhances the payment metrics functionality in the admin module by adding support for the "yesterday" period and introducing growth percentage calculations. The changes span across controllers, routes, and services.

### Enhancements to Payment Metrics:

* **Controller Updates:**
  * [`src/controllers/admin.controller.js`](diffhunk://#diff-056aaff6f16777d5fe3aae04d5039611a46ed72790ab9697824e53e938511aabL121-R121): Added "yesterday" to the list of allowed periods for payment metrics retrieval.

* **Route Documentation Improvements:**
  * [`src/routes/v1/admin.route.js`](diffhunk://#diff-e72bd8d0b3cb8037c3896a9628c71ddfc4e1e34f5d85f400e77f045a2259b896L409-R410): Updated the Swagger documentation to reflect the new functionality of retrieving payment values and growth percentages. [[1]](diffhunk://#diff-e72bd8d0b3cb8037c3896a9628c71ddfc4e1e34f5d85f400e77f045a2259b896L409-R410) [[2]](diffhunk://#diff-e72bd8d0b3cb8037c3896a9628c71ddfc4e1e34f5d85f400e77f045a2259b896L421-R421) [[3]](diffhunk://#diff-e72bd8d0b3cb8037c3896a9628c71ddfc4e1e34f5d85f400e77f045a2259b896R430-R450)

* **Service Logic Enhancements:**
  * [`src/services/admin.service.js`](diffhunk://#diff-80beb6ef668ca00e266e95a002f1d3d7e97bef2a463b64e57530970b026749ffL527-R595): Modified the `getPaymentTotal` function to calculate and return both current and previous period totals along with the growth percentage.