### PR TITLE
feat: add fullName field to requesterInfo and update related schemas and validations

### DIFF
--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -66,12 +66,14 @@ components:
               firebaseUrl:
                 type: string
         notaryService:
-          type: string
+          $ref: '#/components/schemas/NotarizationService'
         notaryField:
-          type: string
+          $ref: '#/components/schemas/NotarizationField'
         requesterInfo:
           type: object
           properties:
+            fullName:
+              type: string
             citizenId:
               type: string
             phoneNumber:

--- a/src/models/document.model.js
+++ b/src/models/document.model.js
@@ -57,6 +57,10 @@ const documentSchema = new mongoose.Schema({
     },
   },
   requesterInfo: {
+    fullName: {
+      type: String,
+      required: true,
+    },
     citizenId: {
       type: String,
       required: true,

--- a/src/routes/v1/notarization.route.js
+++ b/src/routes/v1/notarization.route.js
@@ -38,7 +38,6 @@ router.route('/upload-files').post(
     req.body.notarizationService = JSON.parse(req.body.notarizationService);
     req.body.notarizationField = JSON.parse(req.body.notarizationField);
     req.body.requesterInfo = JSON.parse(req.body.requesterInfo);
-    console.log('Parsed body:', req.body);
 
     req.body.files = req.files.map((file) => file.originalname);
 

--- a/src/routes/v1/notarization.route.js
+++ b/src/routes/v1/notarization.route.js
@@ -25,39 +25,6 @@ const upload = multer({
 
 /**
  * @swagger
- * components:
- *   securitySchemes:
- *     bearerAuth:
- *       type: http
- *       scheme: bearer
- *       bearerFormat: JWT
- *       description: 'JWT authorization header. Use `Bearer <token>` format.'
- *
- *   responses:
- *     BadRequest:
- *       description: Bad Request
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               message:
- *                 type: string
- *                 example: Invalid request parameters
- *     Unauthorized:
- *       description: Unauthorized access
- *       content:
- *         application/json:
- *           schema:
- *             type: object
- *             properties:
- *               message:
- *                 type: string
- *                 example: Unauthorized
- */
-
-/**
- * @swagger
  * tags:
  *   name: Notarizations
  *   description: Notarization document management API
@@ -71,6 +38,7 @@ router.route('/upload-files').post(
     req.body.notarizationService = JSON.parse(req.body.notarizationService);
     req.body.notarizationField = JSON.parse(req.body.notarizationField);
     req.body.requesterInfo = JSON.parse(req.body.requesterInfo);
+    console.log('Parsed body:', req.body);
 
     req.body.files = req.files.map((file) => file.originalname);
 
@@ -192,6 +160,10 @@ router
  *               requesterInfo:
  *                 type: object
  *                 properties:
+ *                   fullName:
+ *                     type: string
+ *                     description: Full name of the requester
+ *                     example: "John Doe"
  *                   citizenId:
  *                     type: string
  *                     description: Citizen ID of the requester
@@ -210,67 +182,7 @@ router
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 _id:
- *                   type: string
- *                   description: Document ID
- *                   example: "60d5ec49f2c1f814d3e8e3c9"
- *                 files:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       filename:
- *                         type: string
- *                         description: Name of the uploaded file
- *                         example: "file1.pdf"
- *                       firebaseUrl:
- *                         type: string
- *                         description: URL of the file in Firebase
- *                         example: "https://firebase.com/path/to/file1.pdf"
- *                 notarizationService:
- *                   type: object
- *                   properties:
- *                     id:
- *                       type: string
- *                       example: "60d5ec49f2c1f814d3e8e3c5"
- *                     name:
- *                       type: string
- *                       example: "Property Deed Notarization"
- *                     fieldId:
- *                       type: string
- *                       example: "60d5ec49f2c1f814d3e8e3c6"
- *                     description:
- *                       type: string
- *                       example: "Notarization for property deed transfer."
- *                     price:
- *                       type: number
- *                       example: 150.00
- *                 notarizationField:
- *                   type: object
- *                   properties:
- *                     id:
- *                       type: string
- *                       example: "60d5ec49f2c1f814d3e8e3c7"
- *                     name:
- *                       type: string
- *                       example: "Real Estate"
- *                     description:
- *                       type: string
- *                       example: "Field related to real estate transactions."
- *                 requesterInfo:
- *                   type: object
- *                   properties:
- *                     citizenId:
- *                       type: string
- *                       example: "123456789"
- *                     phoneNumber:
- *                       type: string
- *                       example: "+1234567890"
- *                     email:
- *                       type: string
- *                       example: "requester@example.com"
+ *               $ref: '#/components/schemas/Notarizations'
  *       "400":
  *         description: Bad Request - Invalid data provided
  *         content:

--- a/src/services/notarization.service.js
+++ b/src/services/notarization.service.js
@@ -50,24 +50,24 @@ const createDocument = async (documentBody, files, userId) => {
       throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service does not match the provided field');
     }
 
-    if (notarizationFieldDoc.name !== notarizationField.name) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization field name does not match');
-    }
+    // if (notarizationFieldDoc.name !== notarizationField.name) {
+    //   throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization field name does not match');
+    // }
 
-    if (notarizationFieldDoc.description !== notarizationField.description) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization field description does not match');
-    }
-    if (notarizationServiceDoc.name !== notarizationService.name) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service name does not match');
-    }
+    // if (notarizationFieldDoc.description !== notarizationField.description) {
+    //   throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization field description does not match');
+    // }
+    // if (notarizationServiceDoc.name !== notarizationService.name) {
+    //   throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service name does not match');
+    // }
 
-    if (notarizationServiceDoc.description !== notarizationService.description) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service description does not match');
-    }
+    // if (notarizationServiceDoc.description !== notarizationService.description) {
+    //   throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service description does not match');
+    // }
 
-    if (notarizationServiceDoc.price !== notarizationService.price) {
-      throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service price does not match');
-    }
+    // if (notarizationServiceDoc.price !== notarizationService.price) {
+    //   throw new ApiError(httpStatus.BAD_REQUEST, 'Notarization service price does not match');
+    // }
 
     const newDocument = new Document({
       files: [],
@@ -84,6 +84,7 @@ const createDocument = async (documentBody, files, userId) => {
         description: notarizationField.description,
       },
       requesterInfo: {
+        fullName: requesterInfo.fullName,
         citizenId: requesterInfo.citizenId,
         phoneNumber: requesterInfo.phoneNumber,
         email: requesterInfo.email,

--- a/src/validations/notarization.validation.js
+++ b/src/validations/notarization.validation.js
@@ -22,7 +22,7 @@ const createDocument = {
       .required(),
     requesterInfo: Joi.object()
       .keys({
-        fullName: Joi.string(),
+        fullName: Joi.string().required(),
         citizenId: Joi.string().required(),
         phoneNumber: Joi.string().required(),
         email: Joi.string().email().required(),


### PR DESCRIPTION
This pull request includes several updates to the notarization service, focusing on schema references, validation, and logging improvements. The most important changes include updating schema references in the `components` file, adding a new field to the `requesterInfo` object, and modifying the validation schema to require the `fullName` field.

Schema and validation updates:

* [`src/docs/components.yml`](diffhunk://#diff-848be3bdb1e3a2866f0025a7a1348c31f1d74cd2c521c7f99d5b71a9eac90f7aL69-R76): Updated schema references for `notaryService` and `notaryField` to use `#/components/schemas/NotarizationService` and `#/components/schemas/NotarizationField` respectively. Added `fullName` to the `requesterInfo` properties.
* [`src/models/document.model.js`](diffhunk://#diff-86a74ccfed1f86363238939781992b39e47b05617664d8bd84460163fed8ec96R60-R63): Added `fullName` field to the `requesterInfo` object and made it required.
* [`src/validations/notarization.validation.js`](diffhunk://#diff-7c5b41ec5b6dda0df4ade8d1f7e052e30e43baa6a6d1b5dfdb205fcc6c46c9beL25-R25): Updated validation schema to make `fullName` a required field in the `requesterInfo` object.

Error handling:

* [`src/services/notarization.service.js`](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L53-R70): Commented out various error checks related to notarization field and service properties. [[1]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L53-R70) [[2]](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1R87)

Documentation cleanup:

* [`src/routes/v1/notarization.route.js`](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659L26-L58): Removed redundant Swagger documentation for security schemes and responses. Updated Swagger documentation to reference `#/components/schemas/Notarizations`. [[1]](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659L26-L58) [[2]](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659R163-R166) [[3]](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659L213-R185)