### PR TITLE
fix: correct response status in getAllNotarizations and update documentation for createdAt field

### DIFF
--- a/src/controllers/notarization.controller.js
+++ b/src/controllers/notarization.controller.js
@@ -97,7 +97,7 @@ const getApproveHistory = catchAsync(async (req, res) => {
 const getAllNotarizations = catchAsync(async (req, res) => {
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
   const notarizations = await notarizationService.getAllNotarizations({}, options);
-  res.send(notarizations);
+  res.status(httpStatus.OK).send(notarizations);
 });
 
 const approveSignatureByUser = catchAsync(async (req, res) => {

--- a/src/controllers/notarization.controller.js
+++ b/src/controllers/notarization.controller.js
@@ -95,8 +95,9 @@ const getApproveHistory = catchAsync(async (req, res) => {
 });
 
 const getAllNotarizations = catchAsync(async (req, res) => {
+  const filter = {};
   const options = pick(req.query, ['sortBy', 'limit', 'page']);
-  const notarizations = await notarizationService.getAllNotarizations({}, options);
+  const notarizations = await notarizationService.getAllNotarizations(filter, options);
   res.status(httpStatus.OK).send(notarizations);
 });
 

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -97,6 +97,8 @@ components:
           createdAt:
             type: string
             format: date-time
+          status:
+            type: string
     Session:
       type: object
       properties:

--- a/src/docs/components.yml
+++ b/src/docs/components.yml
@@ -94,6 +94,9 @@ components:
             - digitalSignature
             - completed
             - rejected
+          createdAt:
+            type: string
+            format: date-time
     Session:
       type: object
       properties:

--- a/src/models/plugins/toJSON.plugin.js
+++ b/src/models/plugins/toJSON.plugin.js
@@ -31,8 +31,8 @@ const toJSON = (schema) => {
       ret.id = ret._id.toString();
       delete ret._id;
       delete ret.__v;
-      delete ret.createdAt;
-      delete ret.updatedAt;
+      // delete ret.createdAt;
+      // delete ret.updatedAt;
       if (transform) {
         return transform(doc, ret, options);
       }

--- a/src/routes/v1/notarization.route.js
+++ b/src/routes/v1/notarization.route.js
@@ -244,60 +244,7 @@ router
  *       - bearerAuth: []
  *     responses:
  *       "200":
- *         description: Successfully retrieved documents for the specified role
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 requesterInfo:
- *                   type: object
- *                   properties:
- *                     citizenId:
- *                       type: string
- *                       example: "123456789012"
- *                     phoneNumber:
- *                       type: string
- *                       example: "941788455"
- *                     email:
- *                       type: string
- *                       example: "123@gmail.com"
- *                 _id:
- *                   type: string
- *                   example: "66f516c6df00763b8878bb89"
- *                 notaryService:
- *                   type: string
- *                   example: "Example Notary Service"
- *                 notaryField:
- *                   type: string
- *                   example: "Example Notary Field"
- *                 userId:
- *                   type: string
- *                   example: "66f46255529f780cf0b20d3e"
- *                 files:
- *                   type: array
- *                   items:
- *                     type: object
- *                     properties:
- *                       _id:
- *                         type: string
- *                         example: "66f516c6df00763b8878bb8b"
- *                       filename:
- *                         type: string
- *                         example: "1727338182964-search-interface-symbol.png"
- *                       firebaseUrl:
- *                         type: string
- *                         example: "https://storage.googleapis.com/congchungonline-6692e.appspot.com/66f516c6df00763b8878bb89/1727338182108-search-interface-symbol.png"
- *                 createdAt:
- *                   type: string
- *                   format: date-time
- *                   example: "2024-09-26T08:09:42.039Z"
- *                 __v:
- *                   type: integer
- *                   example: 1
- *                 status:
- *                   type: string
- *                   example: "processing"
+ *         $ref: '#/components/responses/Notarizations'
  *       "400":
  *         $ref: '#/components/responses/BadRequest'
  *       "401":

--- a/src/services/notarization.service.js
+++ b/src/services/notarization.service.js
@@ -314,8 +314,8 @@ const getApproveHistory = async (userId) => {
 };
 
 const getAllNotarizations = async (filter, options) => {
-  const notatizations = await Document.paginate(filter, options);
-  return notatizations;
+  const notarizations = await Document.paginate(filter, options);
+  return notarizations;
 };
 
 const approveSignatureByUser = async (documentId, amount, signatureImage) => {

--- a/src/services/notarization.service.js
+++ b/src/services/notarization.service.js
@@ -314,10 +314,10 @@ const getApproveHistory = async (userId) => {
 };
 
 const getAllNotarizations = async (filter, options) => {
-  // Apply default options if not provided
-  const page = options.page ? parseInt(options.page, 10) : 1;
-  const limit = options.limit ? parseInt(options.limit, 10) : 10;
+  const page = options.page && options.page > 0 ? parseInt(options.page, 10) : 1;
+  const limit = options.limit && options.limit > 0 ? parseInt(options.limit, 10) : 10;
   const skip = (page - 1) * limit;
+
   const sortBy = options.sortBy || 'createdAt';
 
   const documents = await Document.aggregate([


### PR DESCRIPTION
This pull request includes several updates to the notarization service, focusing on improving the handling of notarization data, enhancing the API documentation, and modifying the data transformation plugin.

### Improvements to notarization data handling:
* [`src/controllers/notarization.controller.js`](diffhunk://#diff-e0b1f720ebbfb63e320fdd6167ac55233175719d3e8487f857df8c9ca5d4e1c6R98-R101): Added a `filter` object and updated the response to use `httpStatus.OK` for the `getAllNotarizations` function.
* [`src/services/notarization.service.js`](diffhunk://#diff-4599cbb117c8f9141bf941f94d5152e00dc0381ea261f9c3cd1db8f596d2e3d1L317-R361): Enhanced the `getAllNotarizations` function to include pagination, sorting, and status tracking aggregation.

### Enhancements to API documentation:
* [`src/routes/v1/notarization.route.js`](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659L247-R247): Replaced detailed response schema with a reference to a shared component in the OpenAPI documentation.
* [`src/docs/components.yml`](diffhunk://#diff-848be3bdb1e3a2866f0025a7a1348c31f1d74cd2c521c7f99d5b71a9eac90f7aR97-R101): Added `createdAt` and `status` properties to the notarization schema.

### Modifications to data transformation plugin:
* [`src/models/plugins/toJSON.plugin.js`](diffhunk://#diff-37c492baa0a78012dbc161b9230dd48a6fc1dd800ebf882cacc0bf2480d36f40L34-R35): Commented out the deletion of `createdAt` and `updatedAt` fields in the `toJSON` plugin.