### PR TITLE
Update validation for get-history-with-status route to include userId in headers

### DIFF
--- a/src/routes/v1/notarization.route.js
+++ b/src/routes/v1/notarization.route.js
@@ -63,7 +63,7 @@ router
   .route('/get-history-with-status')
   .get(
     auth('viewNotarizationHistory'),
-    validate(notarizationValidation.getHistoryByUserId),
+    validate(notarizationValidation.getHistoryWithStatus),
     notarizationController.getHistoryWithStatus
   );
 

--- a/src/validations/notarization.validation.js
+++ b/src/validations/notarization.validation.js
@@ -71,6 +71,12 @@ const getHistoryByUserId = {
   }),
 };
 
+const getHistoryWithStatus = {
+  headers: Joi.object().keys({
+    userId: Joi.string().required(),
+  }),
+};
+
 module.exports = {
   createDocument,
   getHistory,
@@ -78,4 +84,5 @@ module.exports = {
   approveSignatureByUser,
   approveSignatureBySecretary,
   getHistoryByUserId,
+  getHistoryWithStatus,
 };


### PR DESCRIPTION
This pull request includes changes to the notarization history retrieval functionality. The most important changes involve updating the validation schema and modifying the route to use the new validation.

Updates to notarization history retrieval:

* [`src/routes/v1/notarization.route.js`](diffhunk://#diff-8f9d8bd5e5621ea11bed10370ff77d638ef146cea4333577005bf7829e63b659L66-R66): Modified the route to use the new `getHistoryWithStatus` validation instead of `getHistoryByUserId`.
* [`src/validations/notarization.validation.js`](diffhunk://#diff-7c5b41ec5b6dda0df4ade8d1f7e052e30e43baa6a6d1b5dfdb205fcc6c46c9beR74-R87): Added a new validation schema `getHistoryWithStatus` and included it in the module exports.