### PR TITLE
Update CI workflow to use Yarn for dependency installation and testing; add additional environment variables for deployment

### DIFF
--- a/.github/workflows/nodejs-ci.yml
+++ b/.github/workflows/nodejs-ci.yml
@@ -21,12 +21,13 @@ jobs:
           node-version: '14'
 
       - name: Install dependencies
-        run: npm install
+        run: yarn
 
       - name: Run tests
-        run: npm test
+        run: yarn test
         env:
           PORT: ${{ secrets.PORT }}
+          HOST: http://localhost
           MONGODB_URL: ${{ secrets.MONGODB_URL }}
           JWT_SECRET: ${{ secrets.JWT_SECRET }}
           JWT_ACCESS_EXPIRATION_MINUTES: ${{ secrets.JWT_ACCESS_EXPIRATION_MINUTES }}
@@ -55,6 +56,19 @@ jobs:
           FIREBASE_UNIVERSE_DOMAIN: ${{ secrets.FIREBASE_UNIVERSE_DOMAIN }}
           FIREBASE_DATABASE_URL: ${{ secrets.FIREBASE_DATABASE_URL }}
           FIREBASE_STORAGE_BUCKET: ${{ secrets.FIREBASE_STORAGE_BUCKET }}
+          CLIENT_URL: ${{ secrets.CLIENT_URL }}
+          PAYOS_CLIENT_ID: ${{ secrets.PAYOS_CLIENT_ID }}
+          PAYOS_API_KEY: ${{ secrets.PAYOS_API_KEY }}
+          PAYOS_CHECKSUM_KEY: ${{ secrets.PAYOS_CHECKSUM_KEY }}
+          SERVER_URL: ${{ secrets.SERVER_URL }}
+          VIETQR_URL: ${{ secrets.VIETQR_URL }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          ALCHEMY_API_KEY: ${{ secrets.ALCHEMY_API_KEY }}
+          PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
+          CONTRACT_ADDRESS: ${{ secrets.CONTRACT_ADDRESS }}
+          PINATA_API_KEY: ${{ secrets.PINATA_API_KEY }}
+          PINATA_SECRET_KEY: ${{ secrets.PINATA_SECRET_KEY }}
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/nodejs-ci.yml` file to switch from using npm to yarn and to add new environment variables. 

Dependency management and testing:

* Changed the installation and test commands from `npm` to `yarn` for improved performance and consistency.

Environment variables:

* Added several new environment variables, including `HOST`, `CLIENT_URL`, `PAYOS_CLIENT_ID`, `PAYOS_API_KEY`, `PAYOS_CHECKSUM_KEY`, `SERVER_URL`, `VIETQR_URL`, `DOCKER_USERNAME`, `DOCKER_PASSWORD`, `ALCHEMY_API_KEY`, `PRIVATE_KEY`, `CONTRACT_ADDRESS`, `PINATA_API_KEY`, and `PINATA_SECRET_KEY` to support additional configurations and integrations.